### PR TITLE
Don't export pg by default, and define defaultTheme

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -37,8 +37,6 @@ services:
   pg:
     image: postgres:alpine
     restart: always
-    ports:
-        - "5432:5432"
     environment:
       - POSTGRES_PASSWORD=development
       - POSTGRES_USER=admin

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,4 +1,7 @@
 /** @type {import('tailwindcss').Config} */
+
+const defaultTheme = require('tailwindcss/defaultTheme')
+
 module.exports = {
   content: [
     "./src/**/*.{js,jsx,ts,tsx}",


### PR DESCRIPTION
- Removes pg 5432 port exposure by default in docker-compose.yaml
- Defines defaultTheme to the tailwindcss default theme
