### PR TITLE
Update README to make pre-commit step nicer

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 This will set up some hooks that will fix e.g. trailing whitespace or formatting issues when you `git commit`:
 ```
-pip install -r requirements.txt
+pip install pre-commit
 pre-commit install
 pre-commit run --all-files
 ```


### PR DESCRIPTION
Ideally nobody has to install `requirements.txt` locally; since this is just for pre-commit, we just tell the person to install pre-commit.