### PR TITLE
Replace tsx imports, by configuring TypeScript correctly

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -30,6 +30,7 @@
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {
+        "@tsconfig/create-react-app": "^1.0.3",
         "tailwindcss": "^3.3.1"
       }
     },
@@ -3787,6 +3788,12 @@
       "engines": {
         "node": ">=10.13.0"
       }
+    },
+    "node_modules/@tsconfig/create-react-app": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/create-react-app/-/create-react-app-1.0.3.tgz",
+      "integrity": "sha512-sAsKAmKzWJlLWpCTyaUHUhqkQEAGAIaNs90sVbZsBhqBTNTnLkcZUr7U5HLI9EUN8QppfkxfGjvaATSgZQhiGQ==",
+      "dev": true
     },
     "node_modules/@types/aria-query": {
       "version": "5.0.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -51,6 +51,7 @@
     ]
   },
   "devDependencies": {
+    "@tsconfig/create-react-app": "^1.0.3",
     "tailwindcss": "^3.3.1"
   }
 }

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 import { MockedProvider } from '@apollo/react-testing';
+import React from 'react';
 
 it('should render loading state initially', () => {
   render(

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,7 +5,7 @@ import {
   Route
 } from "react-router-dom";
 
-import MainView from './views/MainView.tsx';
+import MainView from './views/MainView';
 
 function App() {
   return (

--- a/frontend/src/components/UserLeaderboard.tsx
+++ b/frontend/src/components/UserLeaderboard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import ProgressBar from './ProgressBar.tsx';
+import ProgressBar from './ProgressBar';
 // import { useQuery, gql } from '@apollo/client';
 
 type UserLeaderboardHeaderProps = {

--- a/frontend/src/components/WorkweekHustle.tsx
+++ b/frontend/src/components/WorkweekHustle.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import UserLeaderboard from './UserLeaderboard.tsx';
+import UserLeaderboard from './UserLeaderboard';
 
 const WorkweekHustle = () => {
     return (<UserLeaderboard challengeName={"Workweek Hustle"} />);

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import './index.css';
 import './App.css';
-import App from './App.tsx';
+import App from './App';
 
 import { ApolloClient, HttpLink, InMemoryCache, ApolloProvider } from '@apollo/client';
 

--- a/frontend/src/views/MainView.tsx
+++ b/frontend/src/views/MainView.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useQuery, gql } from '@apollo/client';
-import WorkweekHustle from '../components/WorkweekHustle.tsx';
+import WorkweekHustle from '../components/WorkweekHustle';
 
 const TEST_QUERY = gql`
   query Test {

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,9 @@
+{
+    "extends": "@tsconfig/create-react-app/tsconfig.json",
+    "include": ["src"],
+    "exclude": ["node_modules", "**/*.spec.ts"],
+    "compilerOptions": {
+        "esModuleInterop": true,
+        "jsx": "react"
+    }
+}


### PR DESCRIPTION
- Adds `@tsconfig/create-react-app` to JS dependencies, adding support for create-react-app typescript configuration
- Adds a `tsconfig.json` inheriting from the default create-react-app configuration
- Enables `esModuleInterop`
- Converts `.tsx` imports to `.tsx`-less imports, which makes red squiggles go away in VSCode

