### PR TITLE
Enable a few pre-commit hooks, and make eslint hook work again

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,11 +2,14 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
     -   repo: https://github.com/pre-commit/pre-commit-hooks
-        rev: v3.2.0
+        rev: v4.4.0
         hooks:
             -   id: trailing-whitespace
             -   id: end-of-file-fixer
             -   id: check-yaml
+            -   id: check-merge-conflict
+            -   id: no-commit-to-branch
+            -   id: requirements-txt-fixer
     -   repo: https://github.com/psf/black
         rev: 23.3.0
         hooks:
@@ -25,3 +28,4 @@ repos:
                     -   eslint-plugin-node@11.1.0
                     -   eslint-plugin-promise@6.1.1
                     -   eslint-plugin-react@7.32.2
+                    -   eslint-config-react-app

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,12 +1,12 @@
+black
 Flask>=2.2
+flask-cors
 Flask-Migrate>=4.0.4
-psycopg2
-pylint
-sqlalchemy
 Flask-SQLAlchemy>=3.0.3
 graphql-core
 git+https://github.com/graphql-python/graphql-server@8b9639e1575a20c7322fb8f19459d743d7201410#egg=graphql-server[flask]
-flask-cors
 pre-commit
-black
+psycopg2
+pylint
 pytest
+sqlalchemy


### PR DESCRIPTION
- In the eslint pre-commit hook, enables the `eslint-config-react-app` dependency, which is required to make `eslint` work out of the box on React apps
- Adds a few other [pre-commit hooks](https://pre-commit.com/hooks.html):
  - `check-merge-conflict`: Fails if there's merge-conflict symbols in your diff
  - `no-commit-to-branch`: Fails if you're committing to `main`
  - `requirements-txt-fixer`: Sorts the requirements.txt file

