### PR TITLE
Fix time-converting to handle singular units

### DIFF
--- a/frontend/src/components/UserLeaderboard.test.tsx
+++ b/frontend/src/components/UserLeaderboard.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react';
-import { UserLeaderboardListingEntry } from './UserLeaderboard';
+import { UserLeaderboardListingEntry, formatDateDifference } from './UserLeaderboard';
 import { MockedProvider } from '@apollo/react-testing';
 import React from 'react';
 
@@ -17,3 +17,43 @@ it('should have the username and steps in the entry', async () => {
   expect(await screen.findByText("test-username")).toBeInTheDocument();
   expect(await screen.findByText("5728")).toBeInTheDocument();
 });
+
+it ('should keep a singular second', async() => {
+  expect(formatDateDifference(1)).toBe("1 second");
+})
+
+it ('should pluralize multiple seconds', async() => {
+  expect(formatDateDifference(23)).toBe("23 seconds");
+})
+
+it ('should convert to minutes', async() => {
+  expect(formatDateDifference(60)).toBe("1 minute");
+})
+
+it ('should truncate to minutes', async() => {
+  expect(formatDateDifference(119)).toBe("1 minute");
+})
+
+it ('should convert to hours', async() => {
+  expect(formatDateDifference(3600)).toBe("1 hour");
+})
+
+it ('should convert to days', async() => {
+  expect(formatDateDifference(86400)).toBe("1 day");
+})
+
+it ('should convert to weeks', async() => {
+  expect(formatDateDifference(604800)).toBe("1 week");
+})
+
+it ('should convert to months', async() => {
+  expect(formatDateDifference(2592000)).toBe("1 month");
+})
+
+it ('should convert to years', async() => {
+  expect(formatDateDifference(31536000)).toBe("1 year");
+})
+
+it ('should handle multiple years', async() => {
+  expect(formatDateDifference(95718330)).toBe("3 years");
+})

--- a/frontend/src/components/UserLeaderboard.tsx
+++ b/frontend/src/components/UserLeaderboard.tsx
@@ -13,22 +13,37 @@ function getCurrentUnixTime(): number {
     return Math.round(currentTime / 1000);
 }
 
-function formatDateDifference(seconds: number): string {
+export function formatDateDifference(seconds: number): string {
+    let unit = "";
+    let quantity = 0;
     if (seconds < 60) {
-        return seconds + " seconds";
+        unit = "second";
+        quantity = seconds;
     } else if (seconds < 3600) {
-        return Math.floor(seconds / 60) + " minutes";
+        quantity = Math.floor(seconds / 60);
+        unit = "minute";
     } else if (seconds < 86400) {
-        return Math.floor(seconds / 3600) + " hours";
+        quantity = Math.floor(seconds / 3600);
+        unit = "hour";
     } else if (seconds < 604800) {
-        return Math.floor(seconds / 86400) + " days";
+        quantity = Math.floor(seconds / 86400);
+        unit = "day";
     } else if (seconds < 2592000) {
-        return Math.floor(seconds / 604800) + " weeks";
+        quantity = Math.floor(seconds / 604800);
+        unit = "week";
     } else if (seconds < 31536000) {
-        return Math.floor(seconds / 2592000) + " months";
+        quantity = Math.floor(seconds / 2592000);
+        unit = "month";
     } else {
-        return Math.floor(seconds / 31536000) + " years";
+        quantity = Math.floor(seconds / 31536000);
+        unit = "year";
     }
+
+    if (quantity > 1) {
+        unit = unit + "s";
+    }
+
+    return quantity + " " + unit;
 }
 
 const UserLeaderboardHeader = ({ title, id, startAt, endAt }: UserLeaderboardHeaderProps) => {


### PR DESCRIPTION
When we compute the "X seconds ago" text in the frontend, we used to pluralize even when it wasn't appropriate, e.g. "1 seconds ago". This changes that, and writes up unit tests.

cc @gogqou 