### PR TITLE
In WorkweekHustle, select only the maximum activity for each day, for each user

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -31,6 +31,7 @@
       },
       "devDependencies": {
         "@tsconfig/create-react-app": "^1.0.3",
+        "@types/lodash": "^4.14.194",
         "tailwindcss": "^3.3.1"
       }
     },
@@ -4202,6 +4203,12 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ=="
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.14.194",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.194.tgz",
+      "integrity": "sha512-r22s9tAS7imvBt2lyHC9B8AGwWnXaYb1tY09oyLkXDs4vArpYJzw09nj8MLx5VfciBPGIb+ZwG0ssYnEPJxn/g==",
+      "dev": true
     },
     "node_modules/@types/mime": {
       "version": "3.0.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -52,6 +52,7 @@
   },
   "devDependencies": {
     "@tsconfig/create-react-app": "^1.0.3",
+    "@types/lodash": "^4.14.194",
     "tailwindcss": "^3.3.1"
   }
 }


### PR DESCRIPTION
We changed the user-activity log model to allow multiple records for a single date per user. This means that the frontend has to do some logic to select just the "latest" record per user per day.

This implements that.

