### PR TITLE
Ensure that we compare against the right prior activity

### DIFF
--- a/frontend/src/components/WorkweekHustle.test.tsx
+++ b/frontend/src/components/WorkweekHustle.test.tsx
@@ -155,5 +155,120 @@ describe('getActivityLogs', () => {
             },
         ]);
     });
-    }
-);
+    it ('should correctly identify the prior activity to compare against', () => {
+        expect(getActivityLogs([
+            {
+                id: 1,
+                user: 'foo',
+                createdAt: 0,
+                recordDate: 0,
+                steps: 1,
+                activeMinutes: 1,
+                distanceKm: 1
+            },
+            {
+                id: 2,
+                user: 'foo',
+                createdAt: 1,
+                recordDate: 0,
+                steps: 2,
+                activeMinutes: 2,
+                distanceKm: 2
+            },
+            {
+                id: 3,
+                user: 'foo',
+                createdAt: 2,
+                recordDate: 0,
+                steps: 3,
+                activeMinutes: 3,
+                distanceKm: 3
+            },
+        ])).toEqual([
+            {
+                id: 1,
+                user: 'foo',
+                createdAt: 0,
+                recordDate: 0,
+                steps: 1,
+                activeMinutes: 1,
+                distanceKm: 1
+            },
+            {
+                id: 2,
+                user: 'foo',
+                createdAt: 1,
+                recordDate: 0,
+                steps: 1,
+                activeMinutes: 1,
+                distanceKm: 1
+            },
+            {
+                id: 3,
+                user: 'foo',
+                createdAt: 2,
+                recordDate: 0,
+                steps: 1,
+                activeMinutes: 1,
+                distanceKm: 1
+            },
+        ]);
+        expect(getActivityLogs([
+            {
+                id: 2,
+                user: 'foo',
+                createdAt: 1,
+                recordDate: 0,
+                steps: 2,
+                activeMinutes: 2,
+                distanceKm: 2
+            },
+            {
+                id: 1,
+                user: 'foo',
+                createdAt: 0,
+                recordDate: 0,
+                steps: 1,
+                activeMinutes: 1,
+                distanceKm: 1
+            },
+            {
+                id: 3,
+                user: 'foo',
+                createdAt: 2,
+                recordDate: 0,
+                steps: 3,
+                activeMinutes: 3,
+                distanceKm: 3
+            },
+        ])).toEqual([
+            {
+                id: 1,
+                user: 'foo',
+                createdAt: 0,
+                recordDate: 0,
+                steps: 1,
+                activeMinutes: 1,
+                distanceKm: 1
+            },
+            {
+                id: 2,
+                user: 'foo',
+                createdAt: 1,
+                recordDate: 0,
+                steps: 1,
+                activeMinutes: 1,
+                distanceKm: 1
+            },
+            {
+                id: 3,
+                user: 'foo',
+                createdAt: 2,
+                recordDate: 0,
+                steps: 1,
+                activeMinutes: 1,
+                distanceKm: 1
+            },
+        ]);
+    });
+});

--- a/frontend/src/components/WorkweekHustle.tsx
+++ b/frontend/src/components/WorkweekHustle.tsx
@@ -53,7 +53,7 @@ export function getActivityLogs(activities: Activity[]): Activity[] {
             const priorActivities = allActivities.filter((priorActivity: Activity): boolean => {
                 return (activity.recordDate == priorActivity.recordDate && activity.user == priorActivity.user && activity.createdAt > priorActivity.createdAt);
             }).sort((a: Activity, b: Activity): number => {
-                return a.createdAt > b.createdAt ? 1 : 0;
+                return a.createdAt > b.createdAt ? -1 : 0;
             });
             if (priorActivities.length < 1) {
                 // This is the first activity for the day.


### PR DESCRIPTION
In a Workweek Hustle, when the user has recorded multiple activities for a date,
and we're rendering the activity log,
we want to show the incremental activites from the prior record in each activity log entry.

For example, if they've recorded 1, then 2, then 3 steps,
the activity log should show 1 step for each entry.

Right now, we're using the wrong thing to compare against - each entry is compared
against just the first entry for the date,
instead of the prior entry.

This fixes that, and adds a unit test to cover this.
