### PR TITLE
Workweek Hustle frontend supports user activity log creation

### DIFF
--- a/frontend/src/DateUtils.test.tsx
+++ b/frontend/src/DateUtils.test.tsx
@@ -8,6 +8,10 @@ it ('should pluralize multiple seconds', async() => {
     expect(formatDateDifference(23)).toBe("23 seconds");
 })
 
+it ('should pluralize zero seconds', async() => {
+    expect(formatDateDifference(0)).toBe("0 seconds");
+})
+
 it ('should convert to minutes', async() => {
     expect(formatDateDifference(60)).toBe("1 minute");
 })

--- a/frontend/src/DateUtils.tsx
+++ b/frontend/src/DateUtils.tsx
@@ -6,7 +6,10 @@ export function getCurrentUnixTime(): number {
 export function formatDateDifference(seconds: number): string {
     let unit = "";
     let quantity = 0;
-    if (seconds < 60) {
+    if (seconds == 0) {
+        unit = "seconds";
+        quantity = seconds;
+    } else if (seconds < 60) {
         unit = "second";
         quantity = seconds;
     } else if (seconds < 3600) {

--- a/frontend/src/components/UserActivityForm.tsx
+++ b/frontend/src/components/UserActivityForm.tsx
@@ -72,95 +72,90 @@ const UserActivityForm = ({ users, startAt, endAt }: UserActivityFormProps) => {
     let user: any;
     let steps: any;
 
-    let innerContent = <div></div>;
-    if (loading) innerContent = <p>Loading...</p>
-    else if (data) {
-        // TODO: celebratory animation
-        reset();
+    if (loading) {
+        return <p>Loading...</p>
     }
-    else {
-        const userElements = users.map((user) => {
-            return <option key={user} value={user}>{user}</option>
-        });
+    const userElements = users.map((user) => {
+        return <option key={user} value={user}>{user}</option>
+    });
 
-        innerContent = (
-            <form
-                className="space-x-1"
-                onSubmit={e => {
-                    e.preventDefault();
-                    const enteredRecordDate = recordDate ? Date.parse(recordDate.value) / 1000 : 0;
-                    const enteredUser = user ? user.value : "";
-                    const enteredSteps = parseInt(steps ? steps.value : "0", 10);
-                    createUserActivity({
-                        variables: {
-                            recordDate: enteredRecordDate,
-                            user: enteredUser,
-                            steps: enteredSteps
-                        }
-                    })
+    return <>
+        <form
+            className="space-x-1"
+            onSubmit={e => {
+                e.preventDefault();
+                const enteredRecordDate = recordDate ? Date.parse(recordDate.value) / 1000 : 0;
+                const enteredUser = user ? user.value : "";
+                const enteredSteps = parseInt(steps ? steps.value : "0", 10);
+                createUserActivity({
+                    variables: {
+                        recordDate: enteredRecordDate,
+                        user: enteredUser,
+                        steps: enteredSteps
+                    }
+                })
+            }}
+        >
+            <input
+                className="rounded p-0.5"
+                type="date"
+                ref={node => {
+                    recordDate = node;
                 }}
+                defaultValue={getDate()}
+                max={getDate(maxDate)}
+                min={getDate(startAt)}
+            />
+            <select
+                className="rounded p-0.5"
+                ref={node => {
+                    user = node;
+                }}>
+                {userElements}
+            </select>
+            <input
+                type='number'
+                className="rounded p-0.5"
+                ref={node => {
+                    steps = node;
+                }}
+                placeholder="Today's total step count"
+            />
+            <button
+                className="p-0.5 rounded bg-teal-400 dark:bg-pink-900 dark:text-slate-400"
+                type="submit"
             >
-                <input
-                    className="rounded p-0.5"
-                    type="date"
-                    ref={node => {
-                        recordDate = node;
-                    }}
-                    defaultValue={getDate()}
-                    max={getDate(maxDate)}
-                    min={getDate(startAt)}
-                />
-                <select
-                    className="rounded p-0.5"
-                    ref={node => {
-                        user = node;
-                    }}>
-                    {userElements}
-                </select>
-                <input
-                    type='number'
-                    className="rounded p-0.5"
-                    ref={node => {
-                        steps = node;
-                    }}
-                    placeholder="Today's total step count"
-                />
+                Log activity
+            </button>
+        </form>
+        {
+            error && <dialog className="absolute inset-0" open>
+                <p className="text-lg font-bold">Error recording your steps:</p>
+                <p>{error.networkError?.message}</p>
                 <button
                     className="p-0.5 rounded bg-teal-400 dark:bg-pink-900 dark:text-slate-400"
-                    type="submit"
+                    value="cancel"
+                    formMethod="dialog"
+                    onClick={() => reset()}
                 >
-                    Log activity
+                    Close
                 </button>
-            </form>
-        );
-
-        if (error) {
-            // TODO: styling for modal
-            innerContent = (
-                <>
-                    <dialog className="absolute inset-0" open>
-                        <p className="text-lg font-bold">Error recording your steps:</p>
-                        <p>{error.networkError?.message}</p>
-                        <button
-                            className="p-0.5 rounded bg-teal-400 dark:bg-pink-900 dark:text-slate-400"
-                            value="cancel"
-                            formMethod="dialog"
-                            onClick={() => reset()}
-                        >
-                            Close
-                        </button>
-                    </dialog>
-                    {innerContent}
-                </>
-            )
+            </dialog>
         }
-    }
-
-    return (
-        <>
-            {innerContent}
-        </>
-    )
+        {
+            data && <dialog className="absolute inset-0" open>
+            <p className="text-lg font-bold">🎉Activity logged!🎉</p>
+            <button
+                className="p-0.5 rounded bg-teal-400 dark:bg-pink-900 dark:text-slate-400"
+                value="cancel"
+                formMethod="dialog"
+                onClick={() => reset()}
+            >
+                Close
+            </button>
+        </dialog>
+        }
+    </>;
 }
 
 export default UserActivityForm;

--- a/frontend/src/components/UserActivityForm.tsx
+++ b/frontend/src/components/UserActivityForm.tsx
@@ -74,9 +74,9 @@ const UserActivityForm = ({ users, startAt, endAt }: UserActivityFormProps) => {
 
     let innerContent = <div></div>;
     if (loading) innerContent = <p>Loading...</p>
-    else if (error) return <p>Error!</p>
     else if (data) {
-        reset()
+        // TODO: celebratory animation
+        reset();
     }
     else {
         const userElements = users.map((user) => {
@@ -85,6 +85,7 @@ const UserActivityForm = ({ users, startAt, endAt }: UserActivityFormProps) => {
 
         innerContent = (
             <form
+                className="space-x-1"
                 onSubmit={e => {
                     e.preventDefault();
                     const enteredRecordDate = recordDate ? Date.parse(recordDate.value) / 1000 : 0;
@@ -97,8 +98,10 @@ const UserActivityForm = ({ users, startAt, endAt }: UserActivityFormProps) => {
                             steps: enteredSteps
                         }
                     })
-                }}>
+                }}
+            >
                 <input
+                    className="rounded p-0.5"
                     type="date"
                     ref={node => {
                         recordDate = node;
@@ -108,26 +111,55 @@ const UserActivityForm = ({ users, startAt, endAt }: UserActivityFormProps) => {
                     min={getDate(startAt)}
                 />
                 <select
+                    className="rounded p-0.5"
                     ref={node => {
                         user = node;
                     }}>
                     {userElements}
                 </select>
                 <input
+                    type='number'
+                    className="rounded p-0.5"
                     ref={node => {
                         steps = node;
                     }}
                     placeholder="Today's total step count"
                 />
-                <button type="submit">Log activity</button>
+                <button
+                    className="p-0.5 rounded bg-teal-400 dark:bg-pink-900 dark:text-slate-400"
+                    type="submit"
+                >
+                    Log activity
+                </button>
             </form>
         );
+
+        if (error) {
+            // TODO: styling for modal
+            innerContent = (
+                <>
+                    <dialog className="absolute inset-0" open>
+                        <p className="text-lg font-bold">Error recording your steps:</p>
+                        <p>{error.networkError?.message}</p>
+                        <button
+                            className="p-0.5 rounded bg-teal-400 dark:bg-pink-900 dark:text-slate-400"
+                            value="cancel"
+                            formMethod="dialog"
+                            onClick={() => reset()}
+                        >
+                            Close
+                        </button>
+                    </dialog>
+                    {innerContent}
+                </>
+            )
+        }
     }
 
     return (
-        <div>
+        <>
             {innerContent}
-        </div>
+        </>
     )
 }
 

--- a/frontend/src/components/UserActivityForm.tsx
+++ b/frontend/src/components/UserActivityForm.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import Activity from '../types/Activity';
+
+type UserActivityFormProps = {
+    activity?: Activity
+}
+
+const UserActivityForm = ({ activity }: UserActivityFormProps) => {
+    return (
+        <div>
+            Activity form here!
+        </div>
+    )
+}
+
+export default UserActivityForm;

--- a/frontend/src/components/UserActivityForm.tsx
+++ b/frontend/src/components/UserActivityForm.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import Activity from '../types/Activity';
 import { useMutation, gql } from '@apollo/client';
 import {FETCH_ACTIVITIES_QUERY} from './WorkweekHustle';
+import {getCurrentUnixTime} from '../DateUtils';
 
 const CREATE_USER_ACTIVITY_MUTATION = gql`
     mutation CreateUserActivity(
@@ -33,11 +34,9 @@ function padDate(date: number): string {
 
 function getDate(time?: number): string {
     let currTime = new Date();
-    console.log("time", time)
     if (time !== undefined) {
         currTime = new Date(time * 1000);
     }
-    console.log("currTime", currTime)
     const formattedMonth = padDate(currTime.getMonth() + 1);
     const formattedDate = padDate(currTime.getDate());
 
@@ -59,6 +58,8 @@ const UserActivityForm = ({ startAt, endAt }: UserActivityFormProps) => {
             ]
         }
     );
+
+    const maxDate = endAt > getCurrentUnixTime() ? getCurrentUnixTime() : endAt;
 
     let recordDate: any;
     let user: any;
@@ -95,7 +96,7 @@ const UserActivityForm = ({ startAt, endAt }: UserActivityFormProps) => {
                         recordDate = node;
                     }}
                     defaultValue={getDate()}
-                    max={getDate(endAt)}
+                    max={getDate(maxDate)}
                     min={getDate(startAt)}
                 />
                 <input

--- a/frontend/src/components/UserActivityForm.tsx
+++ b/frontend/src/components/UserActivityForm.tsx
@@ -1,14 +1,121 @@
 import React from 'react';
 import Activity from '../types/Activity';
+import { useMutation, gql } from '@apollo/client';
+import {FETCH_ACTIVITIES_QUERY} from './WorkweekHustle';
 
-type UserActivityFormProps = {
-    activity?: Activity
+const CREATE_USER_ACTIVITY_MUTATION = gql`
+    mutation CreateUserActivity(
+        $user:String!,
+        $recordDate:Int!,
+        $steps:Int!,
+    ) {
+        createUserActivity(
+            recordDate:$recordDate,
+            user:$user,
+            steps:$steps,
+            activeMinutes:0,
+            distanceKm:0
+        ) {
+            id
+            recordDate
+            user
+            steps
+        }
+    }
+`
+function padDate(date: number): string {
+    let formattedDate = "" + date;
+    if (date < 10) {
+        formattedDate = "0" + formattedDate;
+    }
+    return formattedDate;
 }
 
-const UserActivityForm = ({ activity }: UserActivityFormProps) => {
+function getDate(time?: number): string {
+    let currTime = new Date();
+    console.log("time", time)
+    if (time !== undefined) {
+        currTime = new Date(time * 1000);
+    }
+    console.log("currTime", currTime)
+    const formattedMonth = padDate(currTime.getMonth() + 1);
+    const formattedDate = padDate(currTime.getDate());
+
+    return currTime.getFullYear() + "-" + (formattedMonth) + "-" + formattedDate;
+}
+
+type UserActivityFormProps = {
+    startAt: number
+    endAt: number
+}
+
+const UserActivityForm = ({ startAt, endAt }: UserActivityFormProps) => {
+    const [createUserActivity, {data, loading, error, reset}] = useMutation(
+        CREATE_USER_ACTIVITY_MUTATION,
+        {
+            refetchQueries: [
+                {query: FETCH_ACTIVITIES_QUERY},
+                'FetchActivities'
+            ]
+        }
+    );
+
+    let recordDate: any;
+    let user: any;
+    let steps: any;
+
+    let innerContent = <div></div>;
+    if (loading) innerContent = <p>Loading...</p>
+    else if (error) return <p>Error!</p>
+    else if (data) {
+        reset()
+    }
+    else {
+        console.log("Data", data);
+        innerContent = (
+            <form
+                onSubmit={e => {
+                    e.preventDefault();
+                    console.log("recordDate", recordDate.value);
+                    const enteredRecordDate = recordDate ? Date.parse(recordDate.value) / 1000 : 0;
+                    console.log("enteredRecordDate", enteredRecordDate);
+                    const enteredUser = user ? user.value : "";
+                    const enteredSteps = parseInt(steps ? steps.value : "0", 10);
+                    createUserActivity({
+                        variables: {
+                            recordDate: enteredRecordDate,
+                            user: enteredUser,
+                            steps: enteredSteps
+                        }
+                    })
+                }}>
+                <input
+                    type="date"
+                    ref={node => {
+                        recordDate = node;
+                    }}
+                    defaultValue={getDate()}
+                    max={getDate(endAt)}
+                    min={getDate(startAt)}
+                />
+                <input
+                    ref={node => {
+                        user = node;
+                    }}
+                />
+                <input
+                    ref={node => {
+                        steps = node;
+                    }}
+                />
+                <button type="submit">Log activity</button>
+            </form>
+        );
+    }
+
     return (
         <div>
-            Activity form here!
+            {innerContent}
         </div>
     )
 }

--- a/frontend/src/components/UserActivityLog.tsx
+++ b/frontend/src/components/UserActivityLog.tsx
@@ -40,7 +40,7 @@ const UserActivityLog = ({ data }: UserActivityLogProps) => {
         }
     )
     return (
-        <div>
+        <div className="grow">
             {entries}
         </div>
     )

--- a/frontend/src/components/UserLeaderboard.tsx
+++ b/frontend/src/components/UserLeaderboard.tsx
@@ -26,7 +26,7 @@ const UserLeaderboardHeader = ({ title, id, startAt, endAt }: UserLeaderboardHea
         timingCopy = "Will start in " + formatDateDifference(startAt - getCurrentUnixTime());
     }
     return (
-        <div className="border-b-2 border-slate-50 mb-8 pb-4">
+        <div className="border-b-2 border-slate-50 dark:border-neutral-600 mb-8 pb-4">
             <div className='col-span-3 text-center text-2xl'>{title}</div>
             <div className='col-span-3 text-center'>{timingCopy}</div>
         </div>

--- a/frontend/src/components/UserLeaderboard.tsx
+++ b/frontend/src/components/UserLeaderboard.tsx
@@ -26,7 +26,7 @@ const UserLeaderboardHeader = ({ title, id, startAt, endAt }: UserLeaderboardHea
         timingCopy = "Will start in " + formatDateDifference(startAt - getCurrentUnixTime());
     }
     return (
-        <div>
+        <div className="border-b-2 border-slate-50 mb-8 pb-4">
             <div className='col-span-3 text-center text-2xl'>{title}</div>
             <div className='col-span-3 text-center'>{timingCopy}</div>
         </div>

--- a/frontend/src/components/WorkweekHustle.tsx
+++ b/frontend/src/components/WorkweekHustle.tsx
@@ -134,7 +134,7 @@ const WorkweekHustle = ({id, users, createdAt, startAt, endAt}: WorkweekHustlePr
             </div>
             <UserActivityLog data={activityLogData} />
             <div className="border-t-2 border-slate-50 dark:border-neutral-600 mt-8 pt-4">
-                <UserActivityForm />
+                <UserActivityForm startAt={startAt} endAt={endAt} />
             </div>
         </div>
     );

--- a/frontend/src/components/WorkweekHustle.tsx
+++ b/frontend/src/components/WorkweekHustle.tsx
@@ -120,7 +120,7 @@ const WorkweekHustle = ({id, users, createdAt, startAt, endAt}: WorkweekHustlePr
 
     return (
         <div className="bg-blue-200 dark:bg-indigo-950 dark:text-slate-400 p-2 h-screen flex flex-col">
-            <div className="border-b-2 border-slate-50 mb-8 pb-4">
+            <div className="border-b-2 border-slate-50 dark:border-neutral-600 mb-8 pb-4">
                 <UserLeaderboard
                     challengeName={"Workweek Hustle"}
                     id={id}
@@ -133,7 +133,7 @@ const WorkweekHustle = ({id, users, createdAt, startAt, endAt}: WorkweekHustlePr
                 />
             </div>
             <UserActivityLog data={activityLogData} />
-            <div className="border-t-2 border-slate-50 mt-8 pt-4">
+            <div className="border-t-2 border-slate-50 dark:border-neutral-600 mt-8 pt-4">
                 <UserActivityForm />
             </div>
         </div>

--- a/frontend/src/components/WorkweekHustle.tsx
+++ b/frontend/src/components/WorkweekHustle.tsx
@@ -6,6 +6,7 @@ import Activity from '../types/Activity';
 import UserLeaderboard from './UserLeaderboard';
 import UserActivityLog from './UserActivityLog';
 import ActivityDataPoint from '../types/ActivityDataPoint';
+import UserActivityForm from './UserActivityForm';
 
 export const FETCH_ACTIVITIES_QUERY = gql`
     query FetchActivities($users: [String]!, $recordedAfter: Int!, $recordedBefore: Int!) {
@@ -118,18 +119,23 @@ const WorkweekHustle = ({id, users, createdAt, startAt, endAt}: WorkweekHustlePr
     const activityLogData: Activity[] = getActivityLogs(activities);
 
     return (
-        <div className="bg-blue-200 dark:bg-indigo-950 dark:text-slate-400 p-2">
-            <UserLeaderboard
-                challengeName={"Workweek Hustle"}
-                id={id}
-                users={users}
-                activityData={leaderboardData}
-                createdAt={createdAt}
-                startAt={startAt}
-                endAt={endAt}
-                unit={"steps"}
-            />
+        <div className="bg-blue-200 dark:bg-indigo-950 dark:text-slate-400 p-2 h-screen flex flex-col">
+            <div className="border-b-2 border-slate-50 mb-8 pb-4">
+                <UserLeaderboard
+                    challengeName={"Workweek Hustle"}
+                    id={id}
+                    users={users}
+                    activityData={leaderboardData}
+                    createdAt={createdAt}
+                    startAt={startAt}
+                    endAt={endAt}
+                    unit={"steps"}
+                />
+            </div>
             <UserActivityLog data={activityLogData} />
+            <div className="border-t-2 border-slate-50 mt-8 pt-4">
+                <UserActivityForm />
+            </div>
         </div>
     );
 };

--- a/frontend/src/components/WorkweekHustle.tsx
+++ b/frontend/src/components/WorkweekHustle.tsx
@@ -134,7 +134,7 @@ const WorkweekHustle = ({id, users, createdAt, startAt, endAt}: WorkweekHustlePr
             </div>
             <UserActivityLog data={activityLogData} />
             <div className="border-t-2 border-slate-50 dark:border-neutral-600 mt-8 pt-4">
-                <UserActivityForm startAt={startAt} endAt={endAt} />
+                <UserActivityForm users={users} startAt={startAt} endAt={endAt} />
             </div>
         </div>
     );


### PR DESCRIPTION
- Add form element, some spacing styles
- Add dark-mode colors
- Submit mutation & refresh query; in calendar picker, select default value & limit values
- Limit activity entries to current date or end date, whichever is first
- User dropdown
- Handle zero seconds correctly
- Style form inputs a little
- Add celebratory dialog when logging

![fitbit-challenges-workweek-hustle-form-success](https://user-images.githubusercontent.com/650324/234166158-941812e4-a4bb-46c6-81cf-5c41946f6b94.PNG)
![fitbit-challenges-workweek-hustle-form](https://user-images.githubusercontent.com/650324/234166162-774d0731-0137-4916-b2ac-42cdb56cba8d.PNG)
![fitbit-challenges-workweek-hustle-form-failure](https://user-images.githubusercontent.com/650324/234166165-20fd6a30-97d3-4336-8acb-b8c222251e7a.PNG)
