### PR TITLE
Workweek Hustle challenge finishes

### DIFF
--- a/api/models/workweek_hustle.py
+++ b/api/models/workweek_hustle.py
@@ -1,5 +1,6 @@
 from ..config import db
 import datetime
+from datetime import timezone
 
 
 class WorkweekHustle(db.Model):  # type: ignore
@@ -14,3 +15,15 @@ class WorkweekHustle(db.Model):  # type: ignore
 
     def __repr__(self) -> str:
         return "<WorkweekHustle {id}>".format(id=self.id)
+
+    @property
+    def ended(self) -> bool:
+        return datetime.datetime.now() >= self.end_at
+
+    @property
+    def seal_at(self) -> datetime.datetime:
+        return self.end_at + datetime.timedelta(hours=24)
+
+    @property
+    def sealed(self) -> bool:
+        return datetime.datetime.now() >= self.seal_at

--- a/frontend/src/components/UserActivityForm.tsx
+++ b/frontend/src/components/UserActivityForm.tsx
@@ -181,7 +181,7 @@ const UserActivityForm = ({ challengeId, users, startAt, endAt, editedActivity, 
     const maxDate = endAt > getCurrentUnixTime() ? getCurrentUnixTime() : endAt;
 
     const id = (editedActivity.id === 0) ? 0 : editedActivity.id;
-    const date = (editedActivity.recordDate === "") ? getDate() : editedActivity.recordDate;
+    const date = (editedActivity.recordDate === "") ? getDate(maxDate) : editedActivity.recordDate;
     const selectedUser = (editedActivity.user === "") ? users[0] : editedActivity.user;
     const userElements = users.map((user) => {
         if (user === selectedUser) {

--- a/frontend/src/components/UserActivityForm.tsx
+++ b/frontend/src/components/UserActivityForm.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Confetti from './Confetti';
 import { useMutation, gql } from '@apollo/client';
-import {FETCH_ACTIVITIES_QUERY} from './WorkweekHustle';
+import {FETCH_WORKWEEK_HUSTLE_QUERY} from '../views/ChallengeView';
 import {getCurrentUnixTime} from '../DateUtils';
 import Activity, {EmptyActivity} from '../types/Activity';
 
@@ -120,6 +120,7 @@ const MutationSuccessDialog = ({ reset }: MutationSuccessDialogProps) => {
 }
 
 type UserActivityFormProps = {
+    challengeId: number
     users: string[]
     startAt: number
     endAt: number
@@ -127,7 +128,7 @@ type UserActivityFormProps = {
     editActivityHook: Function
 }
 
-const UserActivityForm = ({ users, startAt, endAt, editedActivity, editActivityHook }: UserActivityFormProps) => {
+const UserActivityForm = ({ challengeId, users, startAt, endAt, editedActivity, editActivityHook }: UserActivityFormProps) => {
     const [
         createUserActivity,
         {
@@ -141,11 +142,9 @@ const UserActivityForm = ({ users, startAt, endAt, editedActivity, editActivityH
         {
             refetchQueries: [
                 {
-                    query: FETCH_ACTIVITIES_QUERY,
+                    query: FETCH_WORKWEEK_HUSTLE_QUERY,
                     variables: {
-                        users,
-                        recordedAfter: startAt,
-                        recordedBefore: endAt,
+                        id: challengeId,
                     }
                 },
                 'FetchActivities'
@@ -165,11 +164,9 @@ const UserActivityForm = ({ users, startAt, endAt, editedActivity, editActivityH
         {
             refetchQueries: [
                 {
-                    query: FETCH_ACTIVITIES_QUERY,
+                    query: FETCH_WORKWEEK_HUSTLE_QUERY,
                     variables: {
-                        users,
-                        recordedAfter: startAt,
-                        recordedBefore: endAt,
+                        id: challengeId,
                     }
                 },
                 'FetchActivities'

--- a/frontend/src/components/UserActivityLog.tsx
+++ b/frontend/src/components/UserActivityLog.tsx
@@ -1,5 +1,5 @@
 import React, {useState} from 'react';
-import Activity, {ActivityDelta, EmptyActivity} from '../types/Activity';
+import Activity, {ActivityDelta, EmptyActivity, ActivityTotal} from '../types/Activity';
 import {formatDateDifference, getCurrentUnixTime} from '../DateUtils';
 import UserActivityForm from './UserActivityForm';
 
@@ -38,12 +38,13 @@ type UserActivityLogProps = {
     challengeId: number
     users: string[]
     deltas: ActivityDelta[]
+    totals: ActivityTotal[]
     startAt: number
     endAt: number
     sealed: boolean
 }
 
-const UserActivityLog = ({ challengeId, users, deltas, startAt, endAt, sealed }: UserActivityLogProps) => {
+const UserActivityLog = ({ challengeId, users, deltas, totals, startAt, endAt, sealed }: UserActivityLogProps) => {
     const [editedActivity, setEditedActivity] = useState(EmptyActivity);
     const entries = deltas.map(
         (delta: ActivityDelta) => {

--- a/frontend/src/components/UserActivityLog.tsx
+++ b/frontend/src/components/UserActivityLog.tsx
@@ -35,13 +35,14 @@ const UserActivityLogEntry = ( {delta, editHook}: UserActivityLogEntryProps) => 
 }
 
 type UserActivityLogProps = {
+    challengeId: number
     users: string[]
     deltas: ActivityDelta[]
     startAt: number
     endAt: number
 }
 
-const UserActivityLog = ({ users, deltas, startAt, endAt }: UserActivityLogProps) => {
+const UserActivityLog = ({ challengeId, users, deltas, startAt, endAt }: UserActivityLogProps) => {
     const [editedActivity, setEditedActivity] = useState(EmptyActivity);
     const entries = deltas.map(
         (delta: ActivityDelta) => {
@@ -54,7 +55,7 @@ const UserActivityLog = ({ users, deltas, startAt, endAt }: UserActivityLogProps
                 {entries}
             </div>
             <div className="border-t-2 border-slate-50 dark:border-neutral-600 mt-8 pt-4">
-                <UserActivityForm users={users} startAt={startAt} endAt={endAt} editedActivity={editedActivity} editActivityHook={setEditedActivity} />
+                <UserActivityForm challengeId={challengeId} users={users} startAt={startAt} endAt={endAt} editedActivity={editedActivity} editActivityHook={setEditedActivity} />
             </div>
         </>
     )

--- a/frontend/src/components/UserActivityLog.tsx
+++ b/frontend/src/components/UserActivityLog.tsx
@@ -40,9 +40,10 @@ type UserActivityLogProps = {
     deltas: ActivityDelta[]
     startAt: number
     endAt: number
+    sealed: boolean
 }
 
-const UserActivityLog = ({ challengeId, users, deltas, startAt, endAt }: UserActivityLogProps) => {
+const UserActivityLog = ({ challengeId, users, deltas, startAt, endAt, sealed }: UserActivityLogProps) => {
     const [editedActivity, setEditedActivity] = useState(EmptyActivity);
     const entries = deltas.map(
         (delta: ActivityDelta) => {
@@ -54,9 +55,9 @@ const UserActivityLog = ({ challengeId, users, deltas, startAt, endAt }: UserAct
             <div className="grow overflow-y-auto">
                 {entries}
             </div>
-            <div className="border-t-2 border-slate-50 dark:border-neutral-600 mt-8 pt-4">
+            { !sealed && <div className="border-t-2 border-slate-50 dark:border-neutral-600 mt-8 pt-4">
                 <UserActivityForm challengeId={challengeId} users={users} startAt={startAt} endAt={endAt} editedActivity={editedActivity} editActivityHook={setEditedActivity} />
-            </div>
+            </div>}
         </>
     )
 }

--- a/frontend/src/components/UserActivityLog.tsx
+++ b/frontend/src/components/UserActivityLog.tsx
@@ -13,6 +13,28 @@ function formatActivityDate(recordDate: string): string {
     )
 }
 
+type PlacementResultEntryProps = {
+    totals: ActivityTotal[]
+}
+
+const PlacementResultEntry = ({ totals }: PlacementResultEntryProps) => {
+    let entryText = `${totals[0].name} won the week with ${totals[0].value} ${totals[0].unit}!`;
+    if (totals.length > 1) {
+        entryText += ` ${totals[1].name} took second with ${totals[1].value} ${totals[1].unit}.`;
+    }
+    if (totals.length > 2) {
+        entryText += ` ${totals[2].name} came in third with ${totals[2].value} ${totals[2].unit}.`;
+    }
+
+    return (
+        <div className="grid grid-cols-3 gap-0 mb-7">
+            <div className="col-span-3 text-center text-lg">
+                {entryText}
+            </div>
+        </div>
+    )
+}
+
 type UserActivityLogEntryProps = {
     delta: ActivityDelta
     editHook: Function
@@ -54,6 +76,7 @@ const UserActivityLog = ({ challengeId, users, deltas, totals, startAt, endAt, s
     return (
         <>
             <div className="grow overflow-y-auto">
+                { sealed && <PlacementResultEntry totals={totals} /> }
                 {entries}
             </div>
             { !sealed && <div className="border-t-2 border-slate-50 dark:border-neutral-600 mt-8 pt-4">

--- a/frontend/src/components/UserLeaderboard.test.tsx
+++ b/frontend/src/components/UserLeaderboard.test.tsx
@@ -2,9 +2,10 @@ import { render, screen } from '@testing-library/react';
 import { UserLeaderboardListingEntry } from './UserLeaderboard';
 import { MockedProvider } from '@apollo/react-testing';
 import React from 'react';
+import {ActivityTotal} from "../types/Activity";
 
 it('should have the username and steps in the entry', async () => {
-  const adp = {
+  const at: ActivityTotal = {
     "name": "test-username",
     "value": 5728,
     "unit": "steps",
@@ -12,7 +13,7 @@ it('should have the username and steps in the entry', async () => {
   const maxSteps = 6173;
   render(
     <MockedProvider mocks={[]}>
-      <UserLeaderboardListingEntry key={"key"} activityDataPoint={adp} maximum={maxSteps} />
+      <UserLeaderboardListingEntry key={"key"} activityTotal={at} maximum={maxSteps} />
     </MockedProvider>,
   );
   expect(await screen.findByText("test-username")).toBeInTheDocument();

--- a/frontend/src/components/UserLeaderboard.test.tsx
+++ b/frontend/src/components/UserLeaderboard.test.tsx
@@ -6,14 +6,14 @@ import {ActivityTotal} from "../types/Activity";
 
 it('should have the username and steps in the entry', async () => {
   const at: ActivityTotal = {
-    "name": "test-username",
-    "value": 5728,
-    "unit": "steps",
+    name: "test-username",
+    value: 5728,
+    unit: "steps",
   }
   const maxSteps = 6173;
   render(
     <MockedProvider mocks={[]}>
-      <UserLeaderboardListingEntry key={"key"} activityTotal={at} maximum={maxSteps} />
+      <UserLeaderboardListingEntry key={"key"} activityTotal={at} maximum={maxSteps} sealed={false} rank={1} />
     </MockedProvider>,
   );
   expect(await screen.findByText("test-username")).toBeInTheDocument();

--- a/frontend/src/components/UserLeaderboard.tsx
+++ b/frontend/src/components/UserLeaderboard.tsx
@@ -67,23 +67,14 @@ export const UserLeaderboardListingEntry = ({ activityTotal, maximum, sealed, ra
 };
 
 type UserLeaderboardListingProps = {
-    users: string[];
     activityTotals: ActivityTotal[];
     unit: string;
     sealed: boolean;
 }
 
-const UserLeaderboardListing = ({ users, activityTotals, unit, sealed }: UserLeaderboardListingProps) => {
-    // Compute the totals per user.
-    const userTotals = users.map((user, _) => {
-        return {
-            'name': user,
-            'value': activityTotals.filter(at => at.name === user).reduce((acc, curr) => acc + curr.value, 0),
-             unit,
-        };
-    }).sort((a, b) => b.value - a.value);
-    const maxValue = Math.max.apply(null, userTotals.map((at, _) => at.value));
-    const entries = userTotals.map((at, idx) => <UserLeaderboardListingEntry key={at.name} activityTotal={at} maximum={maxValue} sealed={sealed} rank={idx + 1} />);
+const UserLeaderboardListing = ({ activityTotals, unit, sealed }: UserLeaderboardListingProps) => {
+    const maxValue = Math.max.apply(null, activityTotals.map((at, _) => at.value));
+    const entries = activityTotals.map((at, idx) => <UserLeaderboardListingEntry key={at.name} activityTotal={at} maximum={maxValue} sealed={sealed} rank={idx + 1} />);
 
     return (
         <div>
@@ -109,7 +100,7 @@ const UserLeaderboard = ({ challengeName, id, users, activityTotals, startAt, en
   return (
     <div>
         <UserLeaderboardHeader title={challengeName} id={id} startAt={startAt} endAt={endAt} ended={ended} sealAt={sealAt} sealed={sealed} />
-        <UserLeaderboardListing users={users} activityTotals={activityTotals} unit={unit} sealed={sealed} />
+        <UserLeaderboardListing activityTotals={activityTotals} unit={unit} sealed={sealed} />
     </div>
   )
 }

--- a/frontend/src/components/UserLeaderboard.tsx
+++ b/frontend/src/components/UserLeaderboard.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ProgressBar from './ProgressBar';
 import {ActivityTotal} from '../types/Activity';
 import {getCurrentUnixTime, formatDateDifference} from '../DateUtils';
+import { Link } from "react-router-dom";
 
 export type UserData = {
     name: string;
@@ -14,9 +15,12 @@ type UserLeaderboardHeaderProps = {
     id: number;
     startAt: number;
     endAt: number;
+    ended: boolean;
+    sealAt: number;
+    sealed: boolean;
 }
 
-const UserLeaderboardHeader = ({ title, id, startAt, endAt }: UserLeaderboardHeaderProps) => {
+const UserLeaderboardHeader = ({ title, id, startAt, endAt, ended, sealAt, sealed }: UserLeaderboardHeaderProps) => {
     let timingCopy = "";
     if (getCurrentUnixTime() > endAt) {
         timingCopy = "Ended " + formatDateDifference(getCurrentUnixTime() - endAt) + " ago";
@@ -27,7 +31,7 @@ const UserLeaderboardHeader = ({ title, id, startAt, endAt }: UserLeaderboardHea
     }
     return (
         <div className="border-b-2 border-slate-50 dark:border-neutral-600 mb-8 pb-4">
-            <div className='col-span-3 text-center text-2xl'>{title}</div>
+            <div className='col-span-3 text-center text-2xl'><Link to={`/challenges/${id}`}>{title}</Link></div>
             <div className='col-span-3 text-center'>{timingCopy}</div>
         </div>
     );
@@ -88,7 +92,7 @@ type UserLeaderboardProps = {
 const UserLeaderboard = ({ challengeName, id, users, activityTotals, startAt, endAt, ended, sealAt, sealed, unit }: UserLeaderboardProps) => {
   return (
     <div>
-        <UserLeaderboardHeader title={challengeName} id={id} startAt={startAt} endAt={endAt} />
+        <UserLeaderboardHeader title={challengeName} id={id} startAt={startAt} endAt={endAt} ended={ended} sealAt={sealAt} sealed={sealed} />
         <UserLeaderboardListing users={users} activityTotals={activityTotals} unit={unit} />
     </div>
   )

--- a/frontend/src/components/UserLeaderboard.tsx
+++ b/frontend/src/components/UserLeaderboard.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import ProgressBar from './ProgressBar';
-import ActivityDataPoint from '../types/ActivityDataPoint';
+import {ActivityTotal} from '../types/Activity';
 import {getCurrentUnixTime, formatDateDifference} from '../DateUtils';
 
 export type UserData = {
@@ -34,36 +34,36 @@ const UserLeaderboardHeader = ({ title, id, startAt, endAt }: UserLeaderboardHea
 };
 
 type UserLeaderboardListingEntryProps = {
-    activityDataPoint: ActivityDataPoint;
+    activityTotal: ActivityTotal;
     maximum: number;
 }
 
-export const UserLeaderboardListingEntry = ({ activityDataPoint, maximum }: UserLeaderboardListingEntryProps) => {
+export const UserLeaderboardListingEntry = ({ activityTotal, maximum }: UserLeaderboardListingEntryProps) => {
     return (
         <div className="grid grid-cols-3 gap-0">
-            <div className="col-span-2">{activityDataPoint.name}</div>
-            <ProgressBar value={activityDataPoint.value} maximum={maximum} />
+            <div className="col-span-2">{activityTotal.name}</div>
+            <ProgressBar value={activityTotal.value} maximum={maximum} />
         </div>
     );
 };
 
 type UserLeaderboardListingProps = {
     users: string[];
-    activityData: ActivityDataPoint[];
+    activityTotals: ActivityTotal[];
     unit: string;
 }
 
-const UserLeaderboardListing = ({ users, activityData, unit }: UserLeaderboardListingProps) => {
+const UserLeaderboardListing = ({ users, activityTotals, unit }: UserLeaderboardListingProps) => {
     // Compute the totals per user.
     const userTotals = users.map((user, _) => {
         return {
             'name': user,
-            'value': activityData.filter(adp => adp.name === user).reduce((acc, curr) => acc + curr.value, 0),
+            'value': activityTotals.filter(at => at.name === user).reduce((acc, curr) => acc + curr.value, 0),
              unit,
         };
     }).sort((a, b) => b.value - a.value);
-    const maxValue = Math.max.apply(null, userTotals.map((adp, _) => adp.value));
-    const entries = userTotals.map((adp, _) => <UserLeaderboardListingEntry key={adp.name} activityDataPoint={adp} maximum={maxValue} />);
+    const maxValue = Math.max.apply(null, userTotals.map((at, _) => at.value));
+    const entries = userTotals.map((at, _) => <UserLeaderboardListingEntry key={at.name} activityTotal={at} maximum={maxValue} />);
 
     return (
         <div>
@@ -76,18 +76,21 @@ type UserLeaderboardProps = {
     challengeName: string;
     id: number;
     users: string[];
-    activityData: ActivityDataPoint[];
+    activityTotals: ActivityTotal[];
     createdAt: number;
     startAt: number;
     endAt: number;
+    ended: boolean;
+    sealAt: number;
+    sealed: boolean;
     unit: string;
 }
 
-const UserLeaderboard = ({ challengeName, id, users, activityData, createdAt, startAt, endAt, unit }: UserLeaderboardProps) => {
+const UserLeaderboard = ({ challengeName, id, users, activityTotals, createdAt, startAt, endAt, unit }: UserLeaderboardProps) => {
   return (
     <div>
         <UserLeaderboardHeader title={challengeName} id={id} startAt={startAt} endAt={endAt} />
-        <UserLeaderboardListing users={users} activityData={activityData} unit={unit} />
+        <UserLeaderboardListing users={users} activityTotals={activityTotals} unit={unit} />
     </div>
   )
 }

--- a/frontend/src/components/UserLeaderboard.tsx
+++ b/frontend/src/components/UserLeaderboard.tsx
@@ -77,7 +77,6 @@ type UserLeaderboardProps = {
     id: number;
     users: string[];
     activityTotals: ActivityTotal[];
-    createdAt: number;
     startAt: number;
     endAt: number;
     ended: boolean;
@@ -86,7 +85,7 @@ type UserLeaderboardProps = {
     unit: string;
 }
 
-const UserLeaderboard = ({ challengeName, id, users, activityTotals, createdAt, startAt, endAt, unit }: UserLeaderboardProps) => {
+const UserLeaderboard = ({ challengeName, id, users, activityTotals, startAt, endAt, ended, sealAt, sealed, unit }: UserLeaderboardProps) => {
   return (
     <div>
         <UserLeaderboardHeader title={challengeName} id={id} startAt={startAt} endAt={endAt} />

--- a/frontend/src/components/UserLeaderboard.tsx
+++ b/frontend/src/components/UserLeaderboard.tsx
@@ -31,7 +31,7 @@ const UserLeaderboardHeader = ({ title, id, startAt, endAt, ended, sealAt, seale
     }
     return (
         <div className="border-b-2 border-slate-50 dark:border-neutral-600 mb-8 pb-4">
-            <div className='col-span-3 text-center text-2xl'><Link to={`/challenges/${id}`}>{title}</Link></div>
+            <div className='col-span-3 text-center text-2xl'><a href={`/challenges/${id}`}>{title}</a></div>
             <div className='col-span-3 text-center'>{timingCopy}</div>
         </div>
     );

--- a/frontend/src/components/UserLeaderboard.tsx
+++ b/frontend/src/components/UserLeaderboard.tsx
@@ -43,12 +43,24 @@ const UserLeaderboardHeader = ({ title, id, startAt, endAt, ended, sealAt, seale
 type UserLeaderboardListingEntryProps = {
     activityTotal: ActivityTotal;
     maximum: number;
+    sealed: boolean;
+    rank: number;
 }
 
-export const UserLeaderboardListingEntry = ({ activityTotal, maximum }: UserLeaderboardListingEntryProps) => {
+export const UserLeaderboardListingEntry = ({ activityTotal, maximum, sealed, rank }: UserLeaderboardListingEntryProps) => {
+    let placeEmoji = "";
+    if (sealed) {
+        if (rank === 1) {
+            placeEmoji = "🥇";
+        } else if (rank === 2) {
+            placeEmoji = "🥈";
+        } else if (rank === 3) {
+            placeEmoji = "🥉";
+        }
+    }
     return (
         <div className="grid grid-cols-3 gap-0">
-            <div className="col-span-2">{activityTotal.name}</div>
+            <div className="col-span-2">{placeEmoji}{activityTotal.name}</div>
             <ProgressBar value={activityTotal.value} maximum={maximum} />
         </div>
     );
@@ -58,9 +70,10 @@ type UserLeaderboardListingProps = {
     users: string[];
     activityTotals: ActivityTotal[];
     unit: string;
+    sealed: boolean;
 }
 
-const UserLeaderboardListing = ({ users, activityTotals, unit }: UserLeaderboardListingProps) => {
+const UserLeaderboardListing = ({ users, activityTotals, unit, sealed }: UserLeaderboardListingProps) => {
     // Compute the totals per user.
     const userTotals = users.map((user, _) => {
         return {
@@ -70,7 +83,7 @@ const UserLeaderboardListing = ({ users, activityTotals, unit }: UserLeaderboard
         };
     }).sort((a, b) => b.value - a.value);
     const maxValue = Math.max.apply(null, userTotals.map((at, _) => at.value));
-    const entries = userTotals.map((at, _) => <UserLeaderboardListingEntry key={at.name} activityTotal={at} maximum={maxValue} />);
+    const entries = userTotals.map((at, idx) => <UserLeaderboardListingEntry key={at.name} activityTotal={at} maximum={maxValue} sealed={sealed} rank={idx + 1} />);
 
     return (
         <div>
@@ -96,7 +109,7 @@ const UserLeaderboard = ({ challengeName, id, users, activityTotals, startAt, en
   return (
     <div>
         <UserLeaderboardHeader title={challengeName} id={id} startAt={startAt} endAt={endAt} ended={ended} sealAt={sealAt} sealed={sealed} />
-        <UserLeaderboardListing users={users} activityTotals={activityTotals} unit={unit} />
+        <UserLeaderboardListing users={users} activityTotals={activityTotals} unit={unit} sealed={sealed} />
     </div>
   )
 }

--- a/frontend/src/components/UserLeaderboard.tsx
+++ b/frontend/src/components/UserLeaderboard.tsx
@@ -22,8 +22,11 @@ type UserLeaderboardHeaderProps = {
 
 const UserLeaderboardHeader = ({ title, id, startAt, endAt, ended, sealAt, sealed }: UserLeaderboardHeaderProps) => {
     let timingCopy = "";
-    if (getCurrentUnixTime() > endAt) {
+    if (ended) {
         timingCopy = "Ended " + formatDateDifference(getCurrentUnixTime() - endAt) + " ago";
+        if (!sealed) {
+            timingCopy = "⚠️" + timingCopy + `. ${formatDateDifference(sealAt - getCurrentUnixTime())} left to record data!⚠️`
+        }
     } else if (getCurrentUnixTime() > startAt) {
         timingCopy = "Started " + formatDateDifference(getCurrentUnixTime() - startAt) + " ago (ends in " + formatDateDifference(endAt - getCurrentUnixTime()) + ")";
     } else {

--- a/frontend/src/components/WorkweekHustle.test.tsx
+++ b/frontend/src/components/WorkweekHustle.test.tsx
@@ -1,80 +1,41 @@
 import { render, screen } from '@testing-library/react';
-import WorkweekHustle, { FETCH_ACTIVITIES_QUERY, getActivityLogs } from './WorkweekHustle';
+import WorkweekHustle, { getActivityLogs } from './WorkweekHustle';
 import { MockedProvider } from '@apollo/react-testing';
 import React from 'react';
 
 
-it('should render loading state initially', async () => {
-    const testFetchWorkweekHustleQueryMock =   {
-        request: {
-            query: FETCH_ACTIVITIES_QUERY,
-            variables: {
-                "users": ['foo', 'bar'],
-                "recordedAfter": 0,
-                "recordedBefore": 0,
-            }
-        },
-        result: {
-            data: {
-                activities: []
-            }
-        }
-    };
-    render(
-        <MockedProvider mocks={[testFetchWorkweekHustleQueryMock]}>
-            <WorkweekHustle id={1} users={['foo', 'bar']} createdAt={0} startAt={0} endAt={0} />
-        </MockedProvider>,
-    );
-    expect(await screen.findByText("Loading...")).toBeInTheDocument();
-});
-
 it('should render when no activities exist', async () => {
-    const testFetchWorkweekHustleQueryMock = {
-        request: {
-            query: FETCH_ACTIVITIES_QUERY,
-                variables: {
-                    "users": ['foo', 'bar'],
-                    "recordedAfter": 0,
-                    "recordedBefore": 0,
-                }
-            },
-            result: {
-                data: {
-                    activities: []
-                }
-        }
-    };
     render(
-        <MockedProvider mocks={[testFetchWorkweekHustleQueryMock]}>
-            <WorkweekHustle id={1} users={['foo', 'bar']} createdAt={0} startAt={0} endAt={0} />
+        <MockedProvider mocks={[]}>
+            <WorkweekHustle
+                id={1}
+                users={['foo', 'bar']}
+                createdAt={0}
+                startAt={0}
+                endAt={0}
+                activities={[]}
+            />
         </MockedProvider>,
     );
     expect(await screen.findByText("Workweek Hustle")).toBeInTheDocument();
   });
 
 it('should select just the latest activity per day', async () => {
-    const testFetchWorkweekHustleQueryMock =   {
-        request: {
-        query: FETCH_ACTIVITIES_QUERY,
-        variables: {
-            "users": ['foo', 'bar'],
-            "recordedAfter": 0,
-            "recordedBefore": 0,
-        }
-        },
-        result: {
-            data: {
-                activities: [
-                    // User has two records for day 0, one with 1 step, and one with 2 steps.
-                    {'id': 1, 'user': 'foo', 'createdAt': 0, 'recordDate': 0, 'steps': 1, 'activeMinutes': 1, 'distanceKm': 1},
-                    {'id': 2, 'user': 'foo', 'createdAt': 1, 'recordDate': 0, 'steps': 2, 'activeMinutes': 2, 'distanceKm': 2},
-                ]
-            }
-        }
-    };
+    const activities = [
+        // User has two records for day 0, one with 1 step, and one with 2 steps.
+        {'id': 1, 'user': 'foo', 'createdAt': 0, 'recordDate': '1000-11-11', 'steps': 1, 'activeMinutes': 1, 'distanceKm': 1},
+        {'id': 2, 'user': 'foo', 'createdAt': 1, 'recordDate': '1000-11-11', 'steps': 2, 'activeMinutes': 2, 'distanceKm': 2},
+    ];
     render(
-        <MockedProvider mocks={[testFetchWorkweekHustleQueryMock]}>
-        <WorkweekHustle id={1} users={['foo', 'bar']} createdAt={0} startAt={0} endAt={0} />
+        <MockedProvider mocks={[]}>
+        <WorkweekHustle
+            id={1}
+            users={['foo', 'bar']}
+            createdAt={0}
+            startAt={0}
+            endAt={0}
+            activities={activities}
+        />
         </MockedProvider>,
     );
     // user only has 2 steps.

--- a/frontend/src/components/WorkweekHustle.test.tsx
+++ b/frontend/src/components/WorkweekHustle.test.tsx
@@ -13,6 +13,9 @@ it('should render when no activities exist', async () => {
                 createdAt={0}
                 startAt={0}
                 endAt={0}
+                ended={false}
+                sealAt={0}
+                sealed={false}
                 activities={[]}
             />
         </MockedProvider>,
@@ -34,6 +37,9 @@ it('should select just the latest activity per day', async () => {
             createdAt={0}
             startAt={0}
             endAt={0}
+            ended={false}
+            sealAt={0}
+            sealed={false}
             activities={activities}
         />
         </MockedProvider>,

--- a/frontend/src/components/WorkweekHustle.tsx
+++ b/frontend/src/components/WorkweekHustle.tsx
@@ -110,7 +110,7 @@ const WorkweekHustle = ({id, users, createdAt, startAt, endAt, ended, sealAt, se
                     unit={"steps"}
                 />
             </div>
-            <UserActivityLog challengeId={id} users={users} deltas={activityLogData} startAt={startAt} endAt={endAt} />
+            <UserActivityLog challengeId={id} users={users} deltas={activityLogData} startAt={startAt} endAt={endAt} sealed={sealed} />
         </div>
     );
 };

--- a/frontend/src/components/WorkweekHustle.tsx
+++ b/frontend/src/components/WorkweekHustle.tsx
@@ -101,7 +101,6 @@ const WorkweekHustle = ({id, users, createdAt, startAt, endAt, ended, sealAt, se
                     id={id}
                     users={users}
                     activityTotals={activityTotals}
-                    createdAt={createdAt}
                     startAt={startAt}
                     endAt={endAt}
                     ended={ended}

--- a/frontend/src/components/WorkweekHustle.tsx
+++ b/frontend/src/components/WorkweekHustle.tsx
@@ -4,7 +4,7 @@ import _ from 'lodash'
 import Activity, {ActivityDelta} from '../types/Activity';
 import UserLeaderboard from './UserLeaderboard';
 import UserActivityLog from './UserActivityLog';
-import ActivityDataPoint from '../types/ActivityDataPoint';
+import {ActivityTotal} from '../types/Activity';
 
 export function getLatestActivityPerUserPerDay(activities: Activity[]): Activity[] {
     return _.chain(activities)
@@ -72,14 +72,17 @@ type WorkweekHustleProps = {
     createdAt: number;
     startAt: number;
     endAt: number;
+    ended: boolean;
+    sealAt: number;
+    sealed: boolean;
     activities: Activity[];
 }
 
-const WorkweekHustle = ({id, users, createdAt, startAt, endAt, activities}: WorkweekHustleProps) => {
+const WorkweekHustle = ({id, users, createdAt, startAt, endAt, ended, sealAt, sealed, activities}: WorkweekHustleProps) => {
     // There might be many logs for a single date.
     // Retrieve just the latest log for a given date.
     // const activities: Activity[] = fetchActivities.data.activities;
-    const leaderboardData: ActivityDataPoint[] = getLatestActivityPerUserPerDay(activities)
+    const activityTotals: ActivityTotal[] = getLatestActivityPerUserPerDay(activities)
         .map((activity: Activity) => {
             return {
                 "name": activity.user,
@@ -97,10 +100,13 @@ const WorkweekHustle = ({id, users, createdAt, startAt, endAt, activities}: Work
                     challengeName={"Workweek Hustle"}
                     id={id}
                     users={users}
-                    activityData={leaderboardData}
+                    activityTotals={activityTotals}
                     createdAt={createdAt}
                     startAt={startAt}
                     endAt={endAt}
+                    ended={ended}
+                    sealAt={sealAt}
+                    sealed={sealed}
                     unit={"steps"}
                 />
             </div>

--- a/frontend/src/components/WorkweekHustle.tsx
+++ b/frontend/src/components/WorkweekHustle.tsx
@@ -87,27 +87,13 @@ type WorkweekHustleProps = {
     createdAt: number;
     startAt: number;
     endAt: number;
+    activities: Activity[];
 }
 
-const WorkweekHustle = ({id, users, createdAt, startAt, endAt}: WorkweekHustleProps) => {
-   const fetchActivities = useQuery(
-        FETCH_ACTIVITIES_QUERY,
-        {
-            variables: {
-                users,
-                "recordedAfter": startAt,
-                "recordedBefore": endAt,
-            }
-        }
-   )
-
-    if (fetchActivities.loading) return <p>Loading...</p>;
-
-    if (fetchActivities.error) return <p>Error : {fetchActivities.error.message}</p>;
-
+const WorkweekHustle = ({id, users, createdAt, startAt, endAt, activities}: WorkweekHustleProps) => {
     // There might be many logs for a single date.
     // Retrieve just the latest log for a given date.
-    const activities: Activity[] = fetchActivities.data.activities;
+    // const activities: Activity[] = fetchActivities.data.activities;
     const leaderboardData: ActivityDataPoint[] = getLatestActivityPerUserPerDay(activities)
         .map((activity: Activity) => {
             return {
@@ -133,7 +119,7 @@ const WorkweekHustle = ({id, users, createdAt, startAt, endAt}: WorkweekHustlePr
                     unit={"steps"}
                 />
             </div>
-            <UserActivityLog users={users} deltas={activityLogData} startAt={startAt} endAt={endAt} />
+            <UserActivityLog challengeId={id} users={users} deltas={activityLogData} startAt={startAt} endAt={endAt} />
         </div>
     );
 };

--- a/frontend/src/components/WorkweekHustle.tsx
+++ b/frontend/src/components/WorkweekHustle.tsx
@@ -1,25 +1,10 @@
 import * as React from 'react';
 import _ from 'lodash'
-import { useQuery, gql } from '@apollo/client';
 
 import Activity, {ActivityDelta} from '../types/Activity';
 import UserLeaderboard from './UserLeaderboard';
 import UserActivityLog from './UserActivityLog';
 import ActivityDataPoint from '../types/ActivityDataPoint';
-
-export const FETCH_ACTIVITIES_QUERY = gql`
-    query FetchActivities($users: [String]!, $recordedAfter: Int!, $recordedBefore: Int!) {
-        activities(users: $users, recordedBefore: $recordedBefore, recordedAfter: $recordedAfter) {
-            id
-            user
-            createdAt
-            recordDate
-            steps
-            activeMinutes
-            distanceKm
-        }
-    }
-`;
 
 export function getLatestActivityPerUserPerDay(activities: Activity[]): Activity[] {
     return _.chain(activities)

--- a/frontend/src/types/Activity.tsx
+++ b/frontend/src/types/Activity.tsx
@@ -31,4 +31,10 @@ export type ActivityDelta = {
     distanceKmDelta: number;
 }
 
+export type ActivityTotal = {
+    name: string;
+    value: number;
+    unit: string;
+}
+
 export default Activity;

--- a/frontend/src/types/ActivityDataPoint.tsx
+++ b/frontend/src/types/ActivityDataPoint.tsx
@@ -1,7 +1,0 @@
-type ActivityDataPoint = {
-    name: string;
-    value: number;
-    unit: string;
-}
-
-export default ActivityDataPoint;

--- a/frontend/src/views/ChallengeView.test.tsx
+++ b/frontend/src/views/ChallengeView.test.tsx
@@ -9,7 +9,7 @@ it('should render loading state initially', async () => {
     request: {
       query: FETCH_WORKWEEK_HUSTLE_QUERY,
       variables: {
-          "id": 0
+          id: 0
       },
     },
     result: {
@@ -31,7 +31,7 @@ it('should handle when the challenge does not exist', async () => {
       request: {
         query: FETCH_WORKWEEK_HUSTLE_QUERY,
         variables: {
-            "id": 0
+            id: 0
         },
       },
       result: {
@@ -51,18 +51,21 @@ it('should handle when the challenge does not exist', async () => {
 
 it('should handle when multiple challenges are found', async () => {
     const testChallenge = {
-        "id": 1,
-        "users": "a,b,c",
-        "createdAt": 1,
-        "startAt": 1,
-        "endAt": 1,
-        "activities": []
+        id: 1,
+        users: "a,b,c",
+        createdAt: 1,
+        startAt: 1,
+        endAt: 1,
+        ended: false,
+        sealAt: 0,
+        sealed: false,
+        activities: []
     }
     const testFetchWorkweekHustleQueryMock =   {
       request: {
         query: FETCH_WORKWEEK_HUSTLE_QUERY,
         variables: {
-            "id": 0
+            id: 0
         },
       },
       result: {

--- a/frontend/src/views/ChallengeView.test.tsx
+++ b/frontend/src/views/ChallengeView.test.tsx
@@ -55,7 +55,8 @@ it('should handle when multiple challenges are found', async () => {
         "users": "a,b,c",
         "createdAt": 1,
         "startAt": 1,
-        "endAt": 1
+        "endAt": 1,
+        "activities": []
     }
     const testFetchWorkweekHustleQueryMock =   {
       request: {

--- a/frontend/src/views/ChallengeView.tsx
+++ b/frontend/src/views/ChallengeView.tsx
@@ -2,52 +2,70 @@ import React from 'react';
 import { useQuery, gql } from '@apollo/client';
 import { useParams } from 'react-router-dom';
 import WorkweekHustle from '../components/WorkweekHustle';
+import Activity from '../types/Activity';
 
 export const FETCH_WORKWEEK_HUSTLE_QUERY = gql`
-  query FetchChallenge($id: Int!) {
-        challenges(id: $id) {
-            id
-            users
-            createdAt
-            startAt
-            endAt
-        }
-    }
+    query FetchChallenge($id: Int!) {
+          challenges(id: $id) {
+              id
+              users
+              createdAt
+              startAt
+              endAt
+              activities {
+                id
+                user
+                createdAt
+                recordDate
+                steps
+                activeMinutes
+                distanceKm
+              }
+          }
+      }
 `;
 
 type ChallengeViewParams = {
-  challengeId: string;
+    challengeId: string;
 }
 
 const ChallengeView = () => {
-  let { challengeId } = useParams<ChallengeViewParams>();
+    let { challengeId } = useParams<ChallengeViewParams>();
     const id = parseInt(challengeId || "0", 10);
 
     const  {loading, error, data } = useQuery(
-      FETCH_WORKWEEK_HUSTLE_QUERY,
-      {variables: { id }},
-   );
+        FETCH_WORKWEEK_HUSTLE_QUERY,
+        {variables: { id }},
+    );
 
-  let innerContent = <p></p>;
-  if (loading) innerContent = <p>Loading...</p>;
-  else if (error) innerContent = <p>Error : {error.message}</p>;
-  else if (data.challenges.length < 1) {
-    innerContent = <p>Error: challenge could not be found!</p>;
-  } else if (data.challenges.length > 1) {
-    innerContent = <p>Error: multiple challenges with that ID were found!</p>
-  } else {
-    const challenge = data.challenges[0];
-    const users = challenge.users.split(",");
-    innerContent = <WorkweekHustle id={id} users={users} createdAt={challenge.createdAt} startAt={challenge.startAt} endAt={challenge.endAt} />;
-  }
+    let innerContent = <p></p>;
+    if (loading) innerContent = <p>Loading...</p>;
+    else if (error) innerContent = <p>Error : {error.message}</p>;
+    else if (data.challenges.length < 1) {
+        innerContent = <p>Error: challenge could not be found!</p>;
+    } else if (data.challenges.length > 1) {
+        innerContent = <p>Error: multiple challenges with that ID were found!</p>
+    } else {
+        const challenge = data.challenges[0];
+        const users = challenge.users.split(",");
+        const activities: Activity[] = challenge.activities;
+        innerContent = <WorkweekHustle
+                            id={id}
+                            users={users}
+                            createdAt={challenge.createdAt}
+                            startAt={challenge.startAt}
+                            endAt={challenge.endAt}
+                            activities={activities}
+                        />;
+    }
 
     return (
-      <div className="dark:bg-neutral-600 dark:text-slate-400 h-screen">
-        <div className="container mx-auto">
-          {innerContent}
+        <div className="dark:bg-neutral-600 dark:text-slate-400 h-screen">
+            <div className="container mx-auto">
+                {innerContent}
+            </div>
         </div>
-      </div>
-  )
+    )
 }
 
 export default ChallengeView;

--- a/frontend/src/views/ChallengeView.tsx
+++ b/frontend/src/views/ChallengeView.tsx
@@ -12,6 +12,9 @@ export const FETCH_WORKWEEK_HUSTLE_QUERY = gql`
               createdAt
               startAt
               endAt
+              ended
+              sealAt
+              sealed
               activities {
                 id
                 user
@@ -55,6 +58,9 @@ const ChallengeView = () => {
                             createdAt={challenge.createdAt}
                             startAt={challenge.startAt}
                             endAt={challenge.endAt}
+                            ended={challenge.ended}
+                            sealAt={challenge.sealAt}
+                            sealed={challenge.sealed}
                             activities={activities}
                         />;
     }


### PR DESCRIPTION
- Expose challenge activities as a GraphQL field, and query that instead
- Delete unused query
- ActivityDatapoint -> ActivityTotal
- Hide form once sealed; limit the default date to the end-date
- Remove unnecessary prop
- Pass seal/end attrs to header; link the title
- Juse use a regular link
- Add warning when between end & seal dates
- Show placements in leaderboard
- Pull total computation into WorkweekHustle
- Upon seal, show victory

Here's what the challenge looks like after the end date, but before the "seal" date:

![fitbit-challenges-workweek-hustle-ended](https://user-images.githubusercontent.com/650324/234738244-2be1555f-114c-454e-968e-226ade723a8d.png)

Here's what it looks like once the challenge is sealed:

![fitbit-challenges-workweek-hustle-ended-sealed](https://user-images.githubusercontent.com/650324/234738275-d4258caf-09d2-4ae6-aa4b-9d17a313ca81.png)
(note the lack of an entry form!)