### PR TITLE
Add unit tests for FitbitClient methods

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,0 +1,1 @@
+postgres-data

--- a/src/python/fitbit_client.py
+++ b/src/python/fitbit_client.py
@@ -60,7 +60,7 @@ class FitbitClient:
         )
 
         if auth_request.status_code != 200:
-            self.logger.warn(
+            self.logger.warning(
                 f"Could not fetch token data. url={auth_request.url}, headers={auth_request.headers}, body={auth_request.text}"
             )
             return None

--- a/src/python/tests/test_fitbit_client.py
+++ b/src/python/tests/test_fitbit_client.py
@@ -139,7 +139,6 @@ def test_authorization_url():
 def test_get_token_data_with_successful_request(
     default_client: FitbitClient, monkeypatch
 ):
-    # Stub out token request.
     response = {"expected_field": "expected_value"}
 
     def mock_post(*args, **kwargs) -> MockPost:
@@ -154,7 +153,6 @@ def test_get_token_data_with_successful_request(
 def test_get_token_data_with_unsuccessful_request(
     default_client: FitbitClient, monkeypatch
 ):
-    # Stub out token request.
     response = None
 
     def mock_post(*args, **kwargs) -> MockPost:

--- a/src/python/tests/test_fitbit_client.py
+++ b/src/python/tests/test_fitbit_client.py
@@ -1,15 +1,29 @@
 from ..fitbit_client import FitbitClient
 import logging
+import pytest
+import requests
 
 
-def test_signing_key():
-    c = FitbitClient(
+@pytest.fixture
+def default_client():
+    return FitbitClient(
         logger=logging.Logger("test-fitbit-client"),
         client_id="test-client-id",
         client_secret="test-client-secret",
     )
 
-    assert "test-client-secret&" == c.signing_key
+
+class MockPost:
+    def __init__(self, response: dict[str, str], status_code: int):
+        self.response = response
+        self.status_code = status_code
+
+    def json(self):
+        return self.response
+
+
+def test_signing_key(default_client):
+    assert "test-client-secret&" == default_client.signing_key
 
 
 def test_verify_signature_correct():

--- a/src/python/tests/test_fitbit_client.py
+++ b/src/python/tests/test_fitbit_client.py
@@ -122,3 +122,18 @@ def test_authorization_url():
         "https://www.fitbit.com/oauth2/authorize?client_id=ABC123&response_type=code&code_challenge=-4cf-Mzo_qg9-uq0F4QwWhRh4AjcAqNx7SbYVsdmyQM&code_challenge_method=S256&scope=activity+heartrate+profile+social"
         == c.authorization_url("01234567890123456789012345678901234567890123456789")
     )
+
+
+def test_get_token_data_with_successful_request(
+    default_client: FitbitClient, monkeypatch
+):
+    # Stub out token request.
+    response = {"expected_field": "expected_value"}
+
+    def mock_post(*args, **kwargs) -> MockPost:
+        return MockPost(response, 200)
+
+    monkeypatch.setattr(requests, "post", mock_post)
+    assert response == default_client.get_token_data(
+        "test-auth-code", "test-code-verifier"
+    )

--- a/src/python/tests/test_fitbit_client.py
+++ b/src/python/tests/test_fitbit_client.py
@@ -1,3 +1,4 @@
+import datetime
 from ..fitbit_client import FitbitClient
 import logging
 import pytest
@@ -34,11 +35,11 @@ class MockPost:
         return self.response
 
 
-def test_signing_key(default_client):
+def test_signing_key(default_client) -> None:
     assert "test-client-secret&" == default_client.signing_key
 
 
-def test_verify_signature_correct():
+def test_verify_signature_correct() -> None:
     c = FitbitClient(
         logger=logging.Logger("test-fitbit-client"),
         client_id="test-client-id",
@@ -60,7 +61,7 @@ def test_verify_signature_correct():
     assert c.verify_signature("Oyv+HBziS4dH/fHJ735cToXX6vs=", json_body)
 
 
-def test_verify_signature_invalid_header():
+def test_verify_signature_invalid_header() -> None:
     c = FitbitClient(
         logger=logging.Logger("test-fitbit-client"),
         client_id="test-client-id",
@@ -82,7 +83,7 @@ def test_verify_signature_invalid_header():
     assert not c.verify_signature("WRONG-HEADER-SIGNATURE", json_body)
 
 
-def test_verify_signature_invalid_body():
+def test_verify_signature_invalid_body() -> None:
     c = FitbitClient(
         logger=logging.Logger("test-fitbit-client"),
         client_id="test-client-id",
@@ -104,7 +105,7 @@ def test_verify_signature_invalid_body():
     assert not c.verify_signature("Oyv+HBziS4dH/fHJ735cToXX6vs=", json_body)
 
 
-def test_authorization_token():
+def test_authorization_token() -> None:
     c = FitbitClient(
         logger=logging.Logger("test-fitbit-client"),
         client_id="ABC123",
@@ -114,7 +115,7 @@ def test_authorization_token():
     assert "QUJDMTIzOkRFRjQ1Ng==" == c.authorization_token
 
 
-def test_code_challenge_from_verifier():
+def test_code_challenge_from_verifier() -> None:
     assert (
         "-4cf-Mzo_qg9-uq0F4QwWhRh4AjcAqNx7SbYVsdmyQM"
         == FitbitClient.code_challenge_from_verifier(
@@ -123,7 +124,7 @@ def test_code_challenge_from_verifier():
     )
 
 
-def test_authorization_url():
+def test_authorization_url() -> None:
     c = FitbitClient(
         logger=logging.Logger("test-fitbit-client"),
         client_id="ABC123",
@@ -138,7 +139,7 @@ def test_authorization_url():
 
 def test_get_token_data_with_successful_request(
     default_client: FitbitClient, monkeypatch
-):
+) -> None:
     response = {"expected_field": "expected_value"}
 
     def mock_post(*args, **kwargs) -> MockPost:
@@ -150,9 +151,9 @@ def test_get_token_data_with_successful_request(
     )
 
 
-def test_get_token_data_with_unsuccessful_request(
+def test_get_token_data_with_failed_request(
     default_client: FitbitClient, monkeypatch
-):
+) -> None:
     response = None
 
     def mock_post(*args, **kwargs) -> MockPost:
@@ -161,4 +162,32 @@ def test_get_token_data_with_unsuccessful_request(
     monkeypatch.setattr(requests, "post", mock_post)
     assert response == default_client.get_token_data(
         "test-auth-code", "test-code-verifier"
+    )
+
+
+def test_get_user_daily_activity_summary_with_successful_request(
+    default_client: FitbitClient, monkeypatch
+) -> None:
+    response = {"expected_field": "expected_value"}
+
+    def mock_get(*args, **kwargs) -> MockPost:
+        return MockPost(response, 200)
+
+    monkeypatch.setattr(requests, "get", mock_get)
+    assert response == default_client.get_user_daily_activity_summary(
+        "test-user-id", "test-access-token", datetime.datetime.now()
+    )
+
+
+def test_get_user_daily_activity_summary_with_failed_request(
+    default_client: FitbitClient, monkeypatch
+) -> None:
+    response = {"errors": ["some errors"]}
+
+    def mock_get(*args, **kwargs) -> MockPost:
+        return MockPost(response, 400)
+
+    monkeypatch.setattr(requests, "get", mock_get)
+    assert response == default_client.get_user_daily_activity_summary(
+        "test-user-id", "test-access-token", datetime.datetime.now()
     )

--- a/src/python/tests/test_fitbit_client.py
+++ b/src/python/tests/test_fitbit_client.py
@@ -191,3 +191,28 @@ def test_get_user_daily_activity_summary_with_failed_request(
     assert response == default_client.get_user_daily_activity_summary(
         "test-user-id", "test-access-token", datetime.datetime.now()
     )
+
+
+def test_refresh_user_tokens_with_successful_request(
+    default_client: FitbitClient, monkeypatch
+) -> None:
+    response = {"expected_field": "expected_value"}
+
+    def mock_post(*args, **kwargs) -> MockPost:
+        return MockPost(response, 200)
+
+    monkeypatch.setattr(requests, "post", mock_post)
+    assert response == default_client.refresh_user_tokens("test-refresh-token")
+
+
+def test_refresh_user_tokens_with_failed_request(
+    default_client: FitbitClient, monkeypatch
+) -> None:
+    response = None
+
+    def mock_post(*args, **kwargs) -> MockPost:
+        return MockPost(response, 400)
+
+    monkeypatch.setattr(requests, "post", mock_post)
+    with pytest.raises(ValueError):
+        default_client.refresh_user_tokens("test-refresh-token")


### PR DESCRIPTION
- Create client fixture that we can reuse, and a post mock object
- Add unit test for get_token_data happy path
- Add test for get_token_data unhappy path
- Fix deprecated method call
- Add unit tests for get_user_daily_activity_summary
- Add unit tests for refresh_user_tokens
